### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/doi2bib.sh
+++ b/doi2bib.sh
@@ -11,6 +11,6 @@ args_num_test "$#" 1 1 "A doi string was expected as argument."
 doi="${1}"
 doi=$(trim "${doi}")
 
-curl -sLH "Accept: application/x-bibtex;q=1" "http://dx.doi.org/${doi}"
-#curl -LH "Accept: application/x-bibtex; charset=utf-8" "http://dx.doi.org/${doi}"
+curl -sLH "Accept: application/x-bibtex;q=1" "https://doi.org/${doi}"
+#curl -LH "Accept: application/x-bibtex; charset=utf-8" "https://doi.org/${doi}"
 echo


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates the code that generates new DOI links.

Cheers!